### PR TITLE
podsecurity context kibana, securitycontext initcontainer

### DIFF
--- a/apigateway/helm/templates/deployment.yaml
+++ b/apigateway/helm/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             {{- toYaml .Values.resources.apigwInitContainer | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.apigw.initContainer.securityContext | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ include "apigateway.elasticsecret" . }}

--- a/apigateway/helm/templates/elasticsearch.yaml
+++ b/apigateway/helm/templates/elasticsearch.yaml
@@ -49,11 +49,11 @@ spec:
     fileRealm:
       - secretName: {{ include "apigateway.elasticsecret" . }}
       - secretName: {{ include "apigateway.kibanasecret" . }}
-    {{- if .Values.elasticsearch.extraSecrets }}
-    {{- range .Values.elasticsearch.extraSecrets }}
-    - secretName: {{ tpl .name $ }}
-    {{- end }}
-    {{- end }}
+      {{- if .Values.elasticsearch.extraSecrets }}
+      {{- range .Values.elasticsearch.extraSecrets }}
+      - secretName: {{ tpl .name $ }}
+      {{- end }}
+      {{- end }}
   nodeSets:
   {{- if .Values.elasticsearch.nodeSets }}
     {{- toYaml .Values.elasticsearch.nodeSets | nindent 4 }}

--- a/apigateway/helm/templates/kibana.yaml
+++ b/apigateway/helm/templates/kibana.yaml
@@ -58,6 +58,8 @@ spec:
     spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.kibana.podSecurityContext | nindent 8 }}
       containers:
         - name: kibana
           resources:


### PR DESCRIPTION
changes made:

- securityContext for initContainers[0] using .Values.apigw.initContainer.securityContext
- bugfix: filerealm extrasecrets indentation in elasticsearch.yaml
- kibana podSecurityContext using .Values.kibana.podSecurityContext

