### PR TITLE
Add external-dns annotation for gRPC service

### DIFF
--- a/apigateway/helm/templates/service.yaml
+++ b/apigateway/helm/templates/service.yaml
@@ -92,9 +92,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}-grpc
-  {{- if .Values.grpcService.azureInternalLoadBalancer }}
   annotations:
+  {{- if .Values.grpcService.azureInternalLoadBalancer }}
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  {{- end }}
+  {{- if .Values.grpcService.dnsExternal }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.grpcService.hostname }}
   {{- end }}
   labels:     
     {{- include "common.labels.standard" . | nindent 4 }}

--- a/apigateway/helm/values.yaml
+++ b/apigateway/helm/values.yaml
@@ -100,6 +100,8 @@ grpcService:
   enabled: false
   type: LoadBalancer
   azureInternalLoadBalancer: false
+  dnsExternal: false
+  hostname: ""
 
 # multiple ingresses for ui, admin, ext and rt 
 ingresses: 


### PR DESCRIPTION
This allows to use external-dns for the gRPC service