### PR TITLE
Fix default TLS secret names

### DIFF
--- a/apigateway/helm/templates/ingress.yaml
+++ b/apigateway/helm/templates/ingress.yaml
@@ -62,7 +62,7 @@ spec:
         {{- range $tls.hosts }}
         - {{ . | quote }}
         {{- end }}
-      {{- $secretName := default (printf "%s-%s" $apigwname "tls" ) $tls.secretName }}
+      {{- $secretName := default (printf "%s-%s-%s" $apigwname "tls" $name ) $tls.secretName }}
       secretName: {{ $secretName }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
It does not make any sense to have the same secret assigned to all ingresses.