### PR TITLE
[terracottabigmemorymax] Doc update

### DIFF
--- a/terracottabigmemorymax/helm/README.md
+++ b/terracottabigmemorymax/helm/README.md
@@ -117,10 +117,10 @@ kubectl delete pod tmc-0.
 - Now again start port-forwarding and go to browser and connect to following url -
 
 ```
-https://terracotta-0.terracotta-service.default.svc.cluster.local
+https://tmc-0.terracotta-service.default.svc.cluster.local
 ```
 
-- When asking for user name enter "user" . It should be able to connect and show cluster information on browser.
+- When asking for username enter "user" . It should be able to connect and show cluster information on browser.
 
 ### Prometheus support
 Terracotta BigMemory provides a list of key metrics in Prometheus compatible format over HTTP on TMC endpoint:


### PR DESCRIPTION
@mobasherul : opening this PR as draft because I don't understand also what you meant by that:

```
Now again start port-forwarding and go to browser and connect to following url -
https://terracotta-0.terracotta-service.default.svc.cluster.local
```

My guess is that you wanted to have the user verify the tmc endpoint, but it is also possible to verify the http agents on servers... So not sure. The URL points to the servers, not the tmc. 

Did you mean to ask the user to verify the TMC cluster instead and the URL should be tmc0 then ?