### PR TITLE
Dev aka kibana tls to es

### DIFF
--- a/apigateway/helm/Chart.yaml
+++ b/apigateway/helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/apigateway/helm/README.md
+++ b/apigateway/helm/README.md
@@ -149,9 +149,9 @@ helm upgrade -i -f myvalues.yaml --set ingress.tls.key="$(<key.pem)" --set ingre
 
 | Version | Changes and Description |
 |-----|------|
-| `1.0.0' | Initial release |
-| `1.1.0' | Bug fixes in default values and helper functions for elastic secret names. <br> **Attention:** moved elasticsearch secret keys: <br>elasticSecretName --> elasticsearch.secretName<br>elasticSecretUserKey --> elasticsearch.secretUserKey<br>elasticSecretPasswordKey --> elasticsearch.secretPasswordKey |
-| `1.2.0' | Added Kibana TLS/SSL functionality towards Elasticsearch. Helper function aded for kibana truststore password.
+| `1.0.0` | Initial release |
+| `1.1.0` | Bug fixes in default values and helper functions for elastic secret names. <br> **Attention:** moved elasticsearch secret keys: <br>elasticSecretName --> elasticsearch.secretName<br>elasticSecretUserKey --> elasticsearch.secretUserKey<br>elasticSecretPasswordKey --> elasticsearch.secretPasswordKey |
+| `1.2.0` | Added Kibana TLS/SSL functionality towards Elasticsearch. Helper function aded for kibana truststore password.
 ## Values
 
 | Key | Type | Default | Description |

--- a/apigateway/helm/README.md.gotmpl
+++ b/apigateway/helm/README.md.gotmpl
@@ -150,7 +150,7 @@ helm upgrade -i -f myvalues.yaml --set ingress.tls.key="$(<key.pem)" --set ingre
 
 | Version | Changes and Description |
 |-----|------|
-| `1.0.0' | Initial release |
-| `1.1.0' | Bug fixes in default values and helper functions for elastic secret names. <br> **Attention:** moved elasticsearch secret keys: <br>elasticSecretName --> elasticsearch.secretName<br>elasticSecretUserKey --> elasticsearch.secretUserKey<br>elasticSecretPasswordKey --> elasticsearch.secretPasswordKey |
-| `1.2.0' | Added Kibana TLS/SSL functionality towards Elasticsearch. Helper function aded for kibana truststore password.
+| `1.0.0` | Initial release |
+| `1.1.0` | Bug fixes in default values and helper functions for elastic secret names. <br> **Attention:** moved elasticsearch secret keys: <br>elasticSecretName --> elasticsearch.secretName<br>elasticSecretUserKey --> elasticsearch.secretUserKey<br>elasticSecretPasswordKey --> elasticsearch.secretPasswordKey |
+| `1.2.0` | Added Kibana TLS/SSL functionality towards Elasticsearch. Helper function aded for kibana truststore password.
 {{ template "chart.valuesSection" . }}

--- a/apigateway/helm/README.md.gotmpl
+++ b/apigateway/helm/README.md.gotmpl
@@ -152,5 +152,5 @@ helm upgrade -i -f myvalues.yaml --set ingress.tls.key="$(<key.pem)" --set ingre
 |-----|------|
 | `1.0.0' | Initial release |
 | `1.1.0' | Bug fixes in default values and helper functions for elastic secret names. <br> **Attention:** moved elasticsearch secret keys: <br>elasticSecretName --> elasticsearch.secretName<br>elasticSecretUserKey --> elasticsearch.secretUserKey<br>elasticSecretPasswordKey --> elasticsearch.secretPasswordKey |
-
+| `1.2.0' | Added Kibana TLS/SSL functionality towards Elasticsearch. Helper function aded for kibana truststore password.
 {{ template "chart.valuesSection" . }}

--- a/apigateway/helm/templates/_helper.tpl
+++ b/apigateway/helm/templates/_helper.tpl
@@ -38,6 +38,13 @@ Build the secret name for kibana user
 {{- end }}
 
 {{/*
+Build the secret password for truststore for Kibana
+*/}}
+{{- define "apigateway.kibanatruststorepassword" -}}
+{{- default (printf "%s%s" ( include "common.names.fullname" .) "-truststore-password-kb") .Values.kibana.tls.truststorePasswordSecret }}
+{{- end }}
+
+{{/*
 Build the secret name for keystore for Elasticsearch
 */}}
 {{- define "apigateway.elastickeystoresecret" -}}

--- a/apigateway/helm/templates/kibana.yaml
+++ b/apigateway/helm/templates/kibana.yaml
@@ -106,11 +106,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "apigateway.kibanasecret" . }}
                   key: password
+            {{- if .Values.kibana.tls.enabled }}
             - name: KIBANA_TRUSTSTORE_PASSWORD  
               valueFrom:
                 secretKeyRef:
                   name: {{ include "apigateway.kibanatruststorepassword" . }}
                   key: password
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /status

--- a/apigateway/helm/templates/kibana.yaml
+++ b/apigateway/helm/templates/kibana.yaml
@@ -38,7 +38,13 @@ spec:
     server.publicBaseUrl: https://{{ $defaultHost }}/apigatewayui/dashboardproxy
     server.basePath: /apigatewayui/dashboardproxy
     server.rewriteBasePath: false
-    
+    {{- if .Values.kibana.tls.enabled }}
+    elasticsearch.ssl.truststore.path: /usr/share/kibana/config/elasticsearch-certs/truststore.p12
+    elasticsearch.ssl.truststore.password: "${KIBANA_TRUSTSTORE_PASSWORD}"
+    elasticsearch.ssl.verificationMode: {{ .Values.kibana.tls.verificationMode }}
+    {{- else }}
+    elasticsearch.ssl.verificationMode: none
+    {{- end }}
   http:
     tls:
       selfSignedCertificate:
@@ -72,6 +78,15 @@ spec:
       initContainers:
         {{- toYaml .Values.kibana.extraInitContainers | nindent 8 }}
       {{- end }}
+      {{- if .Values.kibana.tls.enabled }}
+      volumes:
+        - name: elasticsearch-certs
+          secret:
+            secretName: {{ .Values.kibana.tls.secretName }}
+            items:
+              - key: {{ .Values.kibana.tls.trustStoreName }}
+                path: truststore.p12
+      {{- end }}
       containers:
         - name: kibana
           resources:
@@ -91,8 +106,20 @@ spec:
                 secretKeyRef:
                   name: {{ include "apigateway.kibanasecret" . }}
                   key: password
+            - name: KIBANA_TRUSTSTORE_PASSWORD  
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "apigateway.kibanatruststorepassword" . }}
+                  key: password
           readinessProbe:
             httpGet:
               path: /status
               port: 5601
               scheme: HTTP
+          {{- if .Values.kibana.tls.enabled }}
+          volumeMounts:
+            - name: elasticsearch-certs
+              mountPath: /usr/share/kibana/config/elasticsearch-certs/truststore.p12
+              subPath:   truststore.p12
+              readOnly: true
+          {{- end }}

--- a/apigateway/helm/values.yaml
+++ b/apigateway/helm/values.yaml
@@ -659,7 +659,7 @@ kibana:
     # -- File name of the p12 truststore for Kibana
     trustStoreName: ""
     # -- Name of the k8s secret containing the password for above p12 truststore in key 'password'
-    truststorePasswordSecret: dataport-truststore-p12-password
+    truststorePasswordSecret: ""
     # -- TLS verification mode. Either 'none', 'certificate' or 'full'. Full includes hostname verification (service name must be in alt dns for it to work).
     verificationMode: certificate
 

--- a/apigateway/helm/values.yaml
+++ b/apigateway/helm/values.yaml
@@ -650,6 +650,20 @@ kibana:
     # Requires create=true to work.
     roleName: ""
   
+  # -- Enable and configure tls connection from Kibana to Elasticsearch.
+  tls:
+    # -- Whether to enable tls connection from Kibana to Elasticsearch.
+    enabled: false
+    # -- Name of the k8s secret holding the p12 truststore for Kibana
+    secretName: ""
+    # -- File name of the p12 truststore for Kibana
+    trustStoreName: ""
+    # -- Name of the k8s secret containing the password for above p12 truststore in key 'password'
+    truststorePasswordSecret: dataport-truststore-p12-password
+    # -- TLS verification mode. Either 'none', 'certificate' or 'full'. Full includes hostname verification (service name must be in alt dns for it to work).
+    verificationMode: certificate
+
+
 # -- Elasticsearch exporter settings. See https://github.com/prometheus-community/elasticsearch_exporter for details.
 prometheus-elasticsearch-exporter:
 


### PR DESCRIPTION
Hinzufügen von TLS/SLL von Kibana zu Elasticsearch:

- getestet bei Kunden in lokalen Fork. Klappt auf Rancher/k8s
- 1 Änderungen an values.yaml: kibana.tls Einstellungen
- 1 Änderungen an _helper.tpl um Kibana Truststore Passwort zu übergeben
- 3 Änderungen an kibana.yaml mit if kibana.tls.enabled