### PR TITLE
feat: Allow setting `revisionHistoryLimit`

### DIFF
--- a/apigateway/helm/templates/deployment.yaml
+++ b/apigateway/helm/templates/deployment.yaml
@@ -31,7 +31,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/apigateway/helm/templates/deployment.yaml
+++ b/apigateway/helm/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/apigateway/helm/templates/elasticsearch.yaml
+++ b/apigateway/helm/templates/elasticsearch.yaml
@@ -99,6 +99,9 @@ spec:
             {{ toYaml . | nindent 12 }}
             {{- end }}
         spec:
+          {{- with .Values.revisionHistoryLimit }}
+            revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+          {{- end }}
           {{- with .Values.elasticsearch.affinity }}
           affinity:
             {{- tpl (toYaml .) $context  | nindent 12 }}

--- a/apigateway/helm/templates/nginx-deployment.yaml
+++ b/apigateway/helm/templates/nginx-deployment.yaml
@@ -30,6 +30,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-nginx
 spec:
   replicas: 1
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/apigateway/helm/values.yaml
+++ b/apigateway/helm/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+# -- The number of old ReplicaSets to retain to allow rollback.
+# revisionHistoryLimit: 10
+
 image:
   # -- The repository for the image. By default, 
   # this points to the Software AG container repository. 


### PR DESCRIPTION
We'd like to be able to set `revisionHistoryLimit` to limit the count of ReplicaSets which last in kubernetes.

sources:
- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#deploymentspec-v1-apps
- https://github.com/elastic/cloud-on-k8s/pull/5818